### PR TITLE
feat: add AI-assisted engineering focus to CV

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
 					</div>
 
 					<div class="sectionContent">
-						<p>Cloud Native Engineer with over 15 years of experience in SAP ERP and Test Management consulting, possessing high-end technical skills, excellent work capacity, and strong communication abilities. I am a resolute person with a high learning capacity, thriving under pressure to deliver the best results to the team. AWS Solutions Architect Professional focused on cloud-native architectures, developer experience, and automation. I am an outgoing person with a good sense of humor, but only after the third coffee in the morning.
+						<p>Cloud Native Engineer with over 15 years of experience in SAP ERP and Test Management consulting, possessing high-end technical skills, excellent work capacity, and strong communication abilities. I am a resolute person with a high learning capacity, thriving under pressure to deliver the best results to the team. AWS Solutions Architect Professional focused on cloud-native architectures, developer experience, automation, and AI-assisted engineering with agentic workflows. I am an outgoing person with a good sense of humor, but only after the third coffee in the morning.
 						<p>
 					</div>
 				</article>
@@ -68,10 +68,10 @@
 							<li>Simplified and flattened the UX of account and role provisioning processes, improving self-service adoption across teams.</li>
 							<li>Defined the unit and integration testing strategy and led the team to raise test coverage from ~5% to 90%, ensuring robust automation and faster feedback.</li>
 							<li>Refactored and stabilized a critical automation platform, reducing integration test runtime from >30 min to &lt;5 min and unit test to &lt;1 min.</li>
+							<li>Active member of the AI Community of Practice, contributing to the evaluation and standardization of AI-assisted engineering tools and producing specs-oriented programming guidelines for development teams.</li>
 							<li>Created an AWS Glue PoC that helped the integration team reduce massive file processing time from 2 hours to 3 minutes.</li>
 							<li>Migrated CI/CD pipelines from Bamboo to GitHub Actions, increasing reliability through check-in/check-out logic.</li>
 							<li>Contributed to deploying Kubermatic Kubernetes Platform for self-service cluster provisioning at scale.</li>
-							<li>Evaluated and standardized AI-based programming tools (Copilot, Kiro, Cline), producing adoption guidelines.</li>
 							<li>Finalist in internal hackathon with a fully serverless Eco Tracker app built on GCP.</li>
 						</ul>
 					</article>
@@ -115,24 +115,24 @@
 						</div>
 						<li>Communication</li>
 						<div class="container">
-							<div class="skillBar softskill3">75%</div>
+							<div class="skillBar softskill3">80%</div>
 						</div>
-						<li>Agile</li>
+						<li>Cross-functional Collaboration</li>
 						<div class="container">
-							<div class="skillBar softskill4">65%</div>
+							<div class="skillBar softskill4">75%</div>
 						</div>
 
 						<li>AWS Architecting</li>
 						<div class="container">
 							<div class="skillBar techskill1">75%</div>
 						</div>
-						<li>Python / Golang</li>
+						<li>Python</li>
 						<div class="container">
-							<div class="skillBar techskill2">80%</div>
+							<div class="skillBar techskill2">85%</div>
 						</div>
-						<li>Kubernetes</li>
+						<li>AI-Assisted Engineering</li>
 						<div class="container">
-							<div class="skillBar techskill3">65%</div>
+							<div class="skillBar techskill3">80%</div>
 						</div>
 						<li>IaC / Automation</li>
 						<div class="container">
@@ -142,7 +142,7 @@
 					</ul>
 				</div>
 				<div class="sectionContent">
-					<p>Ansible, Artifactory, Bamboo, Docker, Flask, Gatekeeper, AI-assisted engineering, GitHub Actions, GCP, Grafana, Helm, Jenkins, Jira API, Jira Service Desk, JFrog, K8s, Kubermatic KKP, MongoEngine, OPA, Prometheus, SQLAlchemy, Terraform.</p>
+					<p>Agentic AI workflows, AI-assisted engineering, Ansible, Artifactory, Bamboo, Docker, Flask, Gatekeeper, GitHub Actions, GCP, Golang, Grafana, Helm, Jenkins, Jira API, Jira Service Desk, JFrog, K8s, Kubermatic KKP, MongoEngine, OPA, Prometheus, specs-oriented programming, SQLAlchemy, Terraform.</p>
 				</div>
 				<div class="clear"></div>
 			</section>
@@ -170,6 +170,19 @@
 								target="_blank">AWS Solutions Architect Associate SAA-C02</a>
 						</p>
 						<p>Issued August 2020 </p>
+					</article>
+				</div>
+				<div class="clear"></div>
+			</section>
+
+			<section>
+				<div class="sectionTitle">
+					<h1>AI & Engineering Philosophy</h1>
+				</div>
+
+				<div class="sectionContent">
+					<article>
+						<p>I advocate for specs-oriented AI programming: defining clear specifications and acceptance criteria upfront, then leveraging AI agents to accelerate implementation, testing, and iteration. This approach combines human architectural judgment with agentic execution to deliver reliable, well-tested software faster. I also explore multi-agent orchestration patterns to understand how autonomous coding agents can collaborate effectively on complex engineering tasks.</p>
 					</article>
 				</div>
 				<div class="clear"></div>

--- a/style.css
+++ b/style.css
@@ -428,7 +428,7 @@ section:last-child {
 }
 
 .softskill3 {
-	width: 75%;
+	width: 80%;
 	background: linear-gradient(90deg, #ff00ff 0%, #ff0080 100%);
 	box-shadow: 
 		0 0 15px rgba(255, 0, 255, 0.5),
@@ -436,7 +436,7 @@ section:last-child {
 }
 
 .softskill4 {
-	width: 65%;
+	width: 75%;
 	background: linear-gradient(90deg, #ff00ff 0%, #ff0080 100%);
 	box-shadow: 
 		0 0 15px rgba(255, 0, 255, 0.5),
@@ -453,7 +453,7 @@ section:last-child {
 }
 
 .techskill2 {
-	width: 80%;
+	width: 85%;
 	background: linear-gradient(90deg, #00f3ff 0%, #00ffaa 100%);
 	box-shadow: 
 		0 0 15px rgba(0, 243, 255, 0.5),
@@ -462,7 +462,7 @@ section:last-child {
 }
 
 .techskill3 {
-	width: 65%;
+	width: 80%;
 	background: linear-gradient(90deg, #00f3ff 0%, #00ffaa 100%);
 	box-shadow: 
 		0 0 15px rgba(0, 243, 255, 0.5),


### PR DESCRIPTION
## Changes

### Personal Profile
- Added "AI-assisted engineering with agentic workflows" to professional focus areas

### Work Experience (BSH Cloud Native Engineer)
- Rewritten AI bullet: now references AI Community of Practice, specs-oriented programming guidelines
- Moved bullet higher in the list for more visibility (before Glue PoC)

### Key Skills - Bars
- **Python / Golang** → **Python** (85%)
- **Kubernetes** → **AI-Assisted Engineering** (80%)
- **Communication** 75% → 80%
- **Agile** → **Cross-functional Collaboration** (75%)

### Key Skills - Keywords
- Expanded: agentic AI workflows, AI-assisted engineering, specs-oriented programming
- Kept Golang and K8s in keyword list

### New Section: AI & Engineering Philosophy
- Specs-oriented AI programming approach
- Multi-agent orchestration exploration